### PR TITLE
フリーランスの開始年を2015年に修正

### DIFF
--- a/src/_data.json
+++ b/src/_data.json
@@ -16,14 +16,14 @@
   "careers": [
     {
       "term": "2016 - Present",
-      "content": "フリーランスとして活動",
-      "present": true
-    },
-    {
-      "term": "2016 - Present",
       "company": "LiB",
       "link": "https://www.libinc.co.jp/",
       "occupation": "UI/UX Designer",
+      "present": true
+    },
+    {
+      "term": "2015 - Present",
+      "content": "フリーランスとして活動",
       "present": true
     },
     {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/818309/13921548/b634ea42-efbb-11e5-8f41-8a48c18bdf97.png)
フリーランスの開始年を2016年にしていたが、プロフィール文によっては2015年に独立と表記していた為、統一。これに合わせて順番もLiBの下にした。
